### PR TITLE
重写主城药效相关的代码

### DIFF
--- a/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/.mcdefinitions
+++ b/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/.mcdefinitions
@@ -1,0 +1,27 @@
+## run.mcfunction
+
+objective=mainBuild:time
+## 此计分板用于玩家在主城时的药效刷新相关
+## 分数的范围在 0 ~ 100
+## 当分数为 0 时视为需要刷新药效
+## 该分数只有当玩家在主城时才会常驻
+
+tag=mainBuild:effectAddRequest
+## 当主城的玩家在 `"mainBuild:time": objective` 上的分数为 0 时会被添加此标签
+## 此标签用于发起一个给予主城药效的请求
+## 该标签不会常驻
+
+tag=mainBuild:effectRemoveRequest
+## 当主城的玩家离开主城后，会获得这个标签
+## 此标签用于发起一个清理主城药效的请求
+## 该标签不会常驻
+
+
+
+
+
+## otherDimensionTest.mcfunction
+
+tag=mainBuild:isIn
+## 当玩家在主城时会被添加此标签
+## 该标签不会常驻

--- a/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/effectAddRequest.mcfunction
+++ b/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/effectAddRequest.mcfunction
@@ -1,0 +1,22 @@
+# effectAddRequest(
+#    "@a[tag=mainBuild:effectAddRequest]": Player
+# ) -> None
+
+# Install
+# in the commandblockplace, as a repeating function
+
+# Start Condition
+# testfor @a[tag=mainBuild:effectAddRequest,c=1] == Success
+
+
+
+
+
+execute @a[tag=mainBuild:effectAddRequest] ~ ~ ~ effect @s night_vision 20 255 true
+execute @a[tag=mainBuild:effectAddRequest] ~ ~ ~ effect @s instant_health 400 255 false
+execute @a[tag=mainBuild:effectAddRequest] ~ ~ ~ effect @s strength 20 255 true
+execute @a[tag=mainBuild:effectAddRequest] ~ ~ ~ effect @s resistance 20 255 true
+execute @a[tag=mainBuild:effectAddRequest] ~ ~ ~ effect @s fire_resistance 20 255 true
+execute @a[tag=mainBuild:effectAddRequest] ~ ~ ~ effect @s saturation 20 255 true
+execute @a[tag=mainBuild:effectAddRequest] ~ ~ ~ tag @s remove mainBuild:effectAddRequest
+# 添加药效

--- a/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/effectRemoveRequest.mcfunction
+++ b/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/effectRemoveRequest.mcfunction
@@ -1,0 +1,23 @@
+# effectRemoveRequest(
+#    "@a[tag=mainBuild:effectRemoveRequest]": Player
+# ) -> None
+
+# Install
+# in the commandblockplace, as a repeating function
+
+# Start Condition
+# testfor @a[tag=mainBuild:effectRemoveRequest,c=1] == Success
+
+
+
+
+
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ effect @s night_vision 0
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ effect @s instant_health 0
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ effect @s strength 0
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ effect @s resistance 0
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ effect @s fire_resistance 0
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ effect @s saturation 0
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ scoreboard players reset @s mainBuild:time
+execute @a[tag=mainBuild:effectRemoveRequest] ~ ~ ~ tag @s remove mainBuild:effectRemoveRequest
+# 移除药效

--- a/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/otherDimensionTest.mcfunction
+++ b/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/otherDimensionTest.mcfunction
@@ -1,0 +1,14 @@
+# otherDimensionTest() -> None
+
+# Install
+# in the commandblockplace, as a repeating function
+
+# Delay
+# delay ticks = 20 game ticks
+
+
+
+execute @a[x=0.0,y=0.0,z=0.0,r=350.0] ~ ~ ~ tag @s add mainBuild:isIn
+execute @a[tag=!mainBuild:isIn,scores={mainBuild:time=..2147483647}] ~ ~ ~ tag @s add mainBuild:effectRemoveRequest
+execute @a[tag=mainBuild:isIn] ~ ~ ~ tag @s remove mainBuild:isIn
+# 考虑部分玩家可能会去往非主世界维度，因此专门进行这样的处理

--- a/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/run.mcfunction
+++ b/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/run.mcfunction
@@ -1,0 +1,22 @@
+# run() -> None
+
+# Install
+# in the commandblockplace, as a repeating function
+
+
+
+
+
+scoreboard objectives add mainBuild:time dummy
+# 添加计分板
+
+
+
+execute @a[x=0.0,y=0.0,z=0.0,r=300.0] ~ ~ ~ scoreboard players add @s mainBuild:time 0
+execute @a[scores={mainBuild:time=0}] ~ ~ ~ tag @s add mainBuild:effectAddRequest
+# 初始化
+execute @a[scores={mainBuild:time=0..99}] ~ ~ ~ scoreboard players add @s mainBuild:time 1
+execute @a[scores={mainBuild:time=100..}] ~ ~ ~ scoreboard players reset @s mainBuild:time
+# 添加分数以模拟时间计时
+execute @a[x=0.0,y=0.0,z=0.0,r=350.0] ~ ~ ~ tag @s add mainBuild:effectRemoveRequest
+# 为主城之外的玩家清理药效

--- a/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/run.mcfunction
+++ b/Command/正在支持的开发项目/幻想乡或英伦小镇-开发/HotFix/LocalBuildEffect/run.mcfunction
@@ -18,5 +18,5 @@ execute @a[scores={mainBuild:time=0}] ~ ~ ~ tag @s add mainBuild:effectAddReques
 execute @a[scores={mainBuild:time=0..99}] ~ ~ ~ scoreboard players add @s mainBuild:time 1
 execute @a[scores={mainBuild:time=100..}] ~ ~ ~ scoreboard players reset @s mainBuild:time
 # 添加分数以模拟时间计时
-execute @a[x=0.0,y=0.0,z=0.0,r=350.0] ~ ~ ~ tag @s add mainBuild:effectRemoveRequest
+execute @a[x=0.0,y=0.0,z=0.0,rm=350.0] ~ ~ ~ tag @s add mainBuild:effectRemoveRequest
 # 为主城之外的玩家清理药效


### PR DESCRIPTION
# 更新说明
## 药效调整
- `主城药效` 调整为下表
   - `夜视 / 20秒 +256级`
   - `瞬间治疗 / 20秒 +256级`
   - `力量 / 20秒 +256级`
   - `抗性提升 / 20秒 +256级`
   - `防火 / 20秒 +256级`
   - `饱和 / 20秒 +256级`

## 更改 / 常规
- 玩家进入 `主城` 后将会立即获得 `主城药效`
- 每 `5` 秒会重新给予一次上表药效
- 当玩家离开 `主城` 后将会立即去除药效 _[仅 主世界]_

## 问题修复
- 修复了玩家以前往非 `主世界` 维度的方式离开 `主城` 时不能正常清理 `主城药效` 的问题



# 审核
本次更新需要审核，审核者分配如下
@baby20162016 @Happy2018Light 



# 合并
本次更新的审核人员通过后，由下列人员完成善后工作，然后将本次 `拉取请求` 合并入 `主分支`
@Happy2018new 